### PR TITLE
Force at least GCC10

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,4 +34,3 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-      

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,8 +16,6 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
-    compiler: gcc
-    gcc: 10
 
     steps:
     - uses: actions/checkout@v2
@@ -26,6 +24,9 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      env:
+        CC:  gcc-10
+        CXX: g++-10
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,9 +24,6 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-      env:
-        CC:  clang-12
-        CXX: clang++-12
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,8 +25,8 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
       env:
-        CC:  gcc-10
-        CXX: g++-10
+        CC:  clang-12
+        CXX: clang++-12
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,8 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
+    compiler: gcc
+    gcc: 10
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`g++-9` fails to compile `std::from_chars(begin, end, double)`, hopefully `g++-10` does it correctly.